### PR TITLE
WT-4869 Silence deprecation warning for URI.escape

### DIFF
--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -61,7 +61,7 @@ module Paperclip
       if url.respond_to?(:escape)
         url.escape
       else
-        URI.escape(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
+        URI::DEFAULT_PARSER.escape(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
       end
     end
 


### PR DESCRIPTION
We're still using the same implementation (cause it worked for us), but we're now using the non-deprecated method instead.